### PR TITLE
Move all third-party dependencies to theirs own CMakeLists.txt.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/deps/imgui-src"]
 	path = third_party/deps/imgui-src
 	url = https://github.com/ocornut/imgui.git
+[submodule "third_party/deps/assimp-src"]
+	path = third_party/deps/assimp-src
+	url = https://github.com/assimp/assimp.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(tools/cmake/clang_msvc_integration.cmake)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 detect_compilers()
-set_cpp17_standard()
+set_cpp_latest_standard()
 
 # Remove unneeded configurations
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
@@ -31,10 +31,10 @@ add_subdirectory(third_party)
 
 # libraries
 add_subdirectory(src/lr_model)
-
 # exe
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/tools/cmake")
 add_subdirectory(src/lr_app)
 add_subdirectory(src/lr_export)
 
 # tests
+
+set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT "lr_app")

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+
+
+### Build
+
+#### Build and configure as fast as possible
+
+```
+cmake -G "Visual Studio 16 2019" ^
+    -DCMAKE_TOOLCHAIN_FILE=C:\libs\vcpkg\scripts\buildsystems\vcpkg.cmake ^
+    -A x64 ..
+```
+
+This will pull dependencies from vcpkg installed in C:/libs/vcpkg.  
+Otherwise, 
+
+```
+cmake -G "Visual Studio 16 2019" -A x64 ..
+```
+
+This will pull dependencies from github (if not yet downloaded with get submodules)
+and build them as part of building process.
+
+

--- a/src/lr_app/CMakeLists.txt
+++ b/src/lr_app/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(exe_name lr_app)
 
-# TODO: wrap third-party dependencies into CMake's targets and move
-# to third_party folder.
-find_package(DirectX11 REQUIRED)
-
 set(shaders_files
     shaders/vs_basic_phong_lighting.hlsl
     shaders/ps_basic_phong_lighting.hlsl
@@ -60,9 +56,8 @@ set_all_warnings(${exe_name} PRIVATE)
 target_link_libraries(${exe_name} lr_model)
 
 # Generated shaders.
-target_include_directories(${exe_name} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
-# DX11.
-target_include_directories(${exe_name} PUBLIC ${DirectX11_INCLUDE_DIRS})
-target_link_libraries(${exe_name} ${DirectX11_LIBRARY})
-# ImGui
+target_include_directories(${exe_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+# Third-party.
+target_link_libraries(${exe_name} DX11_Integrated)
 target_link_libraries(${exe_name} ImGui_Integrated)

--- a/src/lr_app/render_main.cpp
+++ b/src/lr_app/render_main.cpp
@@ -372,7 +372,7 @@ int WINAPI _tWinMain(HINSTANCE /*hInstance*/, HINSTANCE /*hPrevInstance*/, LPTST
 
         const float x = cosf(yaw) * cosf(pitch);
         const float y = sinf(pitch);
-        const float z = sinf(yaw) * cosf(DegreesToRadians(game.camera_pitch_degrees_));
+        const float z = sinf(yaw) * cosf(pitch);
 
         game.camera_front_dir_ = XMVector3Normalize(XMVectorSet(x, y, z, 0.f));
         game.camera_right_dir_ = XMVector3Normalize(XMVector3Cross(game.camera_front_dir_, game.camera_up_dir_));

--- a/src/lr_export/CMakeLists.txt
+++ b/src/lr_export/CMakeLists.txt
@@ -1,9 +1,5 @@
 set(exe_name lr_export)
 
-# TODO: move to third_party folder.
-find_package(assimp REQUIRED) # models loading
-find_path(stb_image_INCLUDE_DIR NAMES stb_image.h REQUIRED) # textures loading
-
 set(src_files
     export_main.cpp
     )
@@ -16,11 +12,6 @@ set_all_warnings(${exe_name} PRIVATE)
 # Own dependencies.
 target_link_libraries(${exe_name} lr_model)
 
-# Assimp.
-message("Assimp: ${ASSIMP_INCLUDE_DIRS}")
-target_include_directories(${exe_name} PRIVATE ${ASSIMP_INCLUDE_DIRS})
-target_link_libraries(${exe_name} ${ASSIMP_LIBRARIES})
-
-# stb_image.h.
-message("stb_image.h: ${stb_image_INCLUDE_DIR}")
-target_include_directories(${exe_name} PRIVATE ${stb_image_INCLUDE_DIR})
+# Third-party.
+target_link_libraries(${exe_name} Assimp_Integrated)
+target_link_libraries(${exe_name} stb_image_Integrated)

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,1 +1,4 @@
+include(dx11_integration.cmake)
 include(imgui_integration.cmake)
+include(stb_image_integration.cmake)
+include(assimp_integration.cmake)

--- a/third_party/assimp_integration.cmake
+++ b/third_party/assimp_integration.cmake
@@ -1,0 +1,45 @@
+add_library(Assimp_Integrated INTERFACE)
+
+# cmake -G "Visual Studio 16 2019" -DCMAKE_TOOLCHAIN_FILE=C:\libs\vcpkg\scripts\buildsystems\vcpkg.cmake -A x64 ..
+find_package(assimp QUIET) # models loading
+if (${assimp_FOUND})
+    message("Assimp: ${ASSIMP_INCLUDE_DIRS}")
+
+    target_include_directories(Assimp_Integrated INTERFACE ${ASSIMP_INCLUDE_DIRS})
+    target_link_libraries(Assimp_Integrated INTERFACE ${ASSIMP_LIBRARIES})
+else ()
+    FetchContent_Declare(
+        assimp_content
+        SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/assimp-src"
+        FULLY_DISCONNECTED ON)
+    FetchContent_GetProperties(assimp_content)
+    if (NOT assimp_content_POPULATED)
+        FetchContent_Populate(assimp_content)
+    endif ()
+
+    # Assimp unconditionally sets special BUILD_SHARED_LIBS variable
+    # that affects other libs. Remember what the variable was before
+    # Assimp and then change the value to original one.
+    set(xx_assimp_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS} CACHE BOOL "" FORCE)
+
+    # We don't need any exporters;
+    set(ASSIMP_NO_EXPORT ON CACHE BOOL "" FORCE)
+    # and importers;
+    set(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT OFF CACHE BOOL "" FORCE)
+    # only OBJ format.
+    set(ASSIMP_BUILD_OBJ_IMPORTER ON CACHE BOOL "" FORCE)
+
+    add_subdirectory(${assimp_content_SOURCE_DIR} ${assimp_content_BINARY_DIR} EXCLUDE_FROM_ALL)
+    set(BUILD_SHARED_LIBS ${xx_assimp_BUILD_SHARED_LIBS} CACHE BOOL "" FORCE)
+
+    target_link_libraries(Assimp_Integrated INTERFACE assimp)
+
+    target_compile_options(assimp PUBLIC
+        # The std::iterator class template is deprecated
+        /wd4996
+        )
+ 
+    set_target_properties(assimp PROPERTIES FOLDER third_party)
+    set_target_properties(IrrXML PROPERTIES FOLDER third_party)
+    set_target_properties(zlibstatic PROPERTIES FOLDER third_party)
+endif ()

--- a/third_party/dx11_integration.cmake
+++ b/third_party/dx11_integration.cmake
@@ -1,0 +1,7 @@
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../tools/cmake")
+find_package(DirectX11 REQUIRED)
+message("DirectX11: ${DirectX11_LIBRARY}")
+
+add_library(DX11_Integrated INTERFACE)
+target_include_directories(DX11_Integrated INTERFACE ${DirectX11_INCLUDE_DIRS})
+target_link_libraries(DX11_Integrated INTERFACE ${DirectX11_LIBRARY})

--- a/third_party/stb_image_integration.cmake
+++ b/third_party/stb_image_integration.cmake
@@ -1,0 +1,22 @@
+# textures loading
+
+add_library(stb_image_Integrated INTERFACE)
+
+# cmake -G "Visual Studio 16 2019" ^
+#   -DCMAKE_TOOLCHAIN_FILE=C:\libs\vcpkg\scripts\buildsystems\vcpkg.cmake ^
+#   -A x64 ..
+find_path(stb_image_INCLUDE_DIR NAMES stb_image.h)
+if (NOT ${stb_image_INCLUDE_DIR} STREQUAL "stb_image_INCLUDE_DIR-NOTFOUND")
+    message("stb_image.h: ${stb_image_INCLUDE_DIR}")
+    target_include_directories(stb_image_Integrated INTERFACE ${stb_image_INCLUDE_DIR})
+else ()
+    set(stb_image_header
+        "${CMAKE_CURRENT_SOURCE_DIR}/deps/stb_image-src/stb_image.h")
+    set(stb_image_url
+        "https://raw.githubusercontent.com/nothings/stb/master/stb_image.h")
+    if (NOT EXISTS ${stb_image_header})
+        file(DOWNLOAD ${stb_image_url} ${stb_image_header})
+    endif ()
+    get_filename_component(dir ${stb_image_header} DIRECTORY)
+    target_include_directories(stb_image_Integrated INTERFACE "${dir}")
+endif ()

--- a/tools/cmake/utils.cmake
+++ b/tools/cmake/utils.cmake
@@ -1,15 +1,8 @@
 include(CMakePrintHelpers)
 
-macro(set_cpp17_standard)
+macro(set_cpp_latest_standard)
 	set(CXX_STANDARD_REQUIRED ON)
 	set(CMAKE_CXX_STANDARD 20)
-
-	# And `CMAKE_CXX_STANDARD` does not work for Clang on Windows.
-	# Also, MSVC's /std switch needs to be set
-	# (for proper detection of _HAS_CXX17 in std headers)
-	if (clang_on_msvc)
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++20")
-	endif ()
 endmacro()
 
 macro(detect_compilers)


### PR DESCRIPTION
Make it possible to build them if vcpkg was not in use.